### PR TITLE
[OZ#2: M-05] Non-standard ERC-4626 vault functionality

### DIFF
--- a/contracts/vaults/BaseVault.sol
+++ b/contracts/vaults/BaseVault.sol
@@ -199,7 +199,10 @@ abstract contract BaseVault is IVault, ERC20Permit, ERC4626, Capped {
      * @inheritdoc IERC4626
      */
     function previewWithdraw(uint256 assets) public view override(ERC4626, IERC4626) returns (uint256) {
-        return _convertToShares(assets, Math.Rounding.Up);
+        uint256 invertedFee = DENOMINATOR - getWithdrawFeeRatio();
+
+        uint256 assetsIncludingFee = assets.mulDiv(DENOMINATOR, invertedFee, Math.Rounding.Up);
+        return _convertToShares(assetsIncludingFee, Math.Rounding.Up);
     }
 
     /**

--- a/contracts/vaults/BaseVault.sol
+++ b/contracts/vaults/BaseVault.sol
@@ -197,6 +197,9 @@ abstract contract BaseVault is IVault, ERC20Permit, ERC4626, Capped {
 
     /**
      * @inheritdoc IERC4626
+     * @dev This function is supposed to return the exactly number of shares that will be used to
+     * claim assets. Because of rounding issues, this function sometimes overestimate the number of shares
+     * in 1 unit. You can check more about that discussion here: https://ethereum-magicians.org/t/eip-4626-yield-bearing-vault-standard/7900/104
      */
     function previewWithdraw(uint256 assets) public view override(ERC4626, IERC4626) returns (uint256) {
         uint256 invertedFee = DENOMINATOR - getWithdrawFeeRatio();

--- a/test/vaults/STETHVault.ts
+++ b/test/vaults/STETHVault.ts
@@ -289,7 +289,7 @@ describe('STETHVault', () => {
       expect(await vault.assetsOf(user0.address)).to.be.equal(assets.mul(3).sub(3))
     })
 
-    it('previewWithdraw and withdrawn shares should match', async () => {
+    it.only('previewWithdraw and withdrawn shares should match', async () => {
       const assets = ethers.utils.parseEther('100')
       const user0Deposit = assets.mul(2)
       const user1Deposit = assets
@@ -302,21 +302,24 @@ describe('STETHVault', () => {
       await vault.connect(vaultController).startRound()
       await asset.connect(yieldGenerator).transfer(vault.address, ethers.utils.parseEther('103'))
 
-      const user0previewWithdraw = await vault.previewWithdraw(assets.div(2))
-      const user1previewWithdraw = await vault.previewWithdraw(assets.div(2))
+      const user0previewWithdrawAssets = assets.div(2)
+      const user1previewWithdrawAssets = assets.div(4)
+
+      const user0previewWithdraw = await vault.previewWithdraw(user0previewWithdrawAssets)
+      const user1previewWithdraw = await vault.previewWithdraw(user1previewWithdrawAssets)
 
       await expect(async () => await vault.connect(user0).redeem(user0previewWithdraw, user0.address, user0.address))
         .to.changeTokenBalance(
           asset,
           user0,
-          assets.div(2)
+          user0previewWithdrawAssets
         )
 
       await expect(async () => await vault.connect(user1).redeem(user1previewWithdraw, user1.address, user1.address))
         .to.changeTokenBalance(
           asset,
           user1,
-          assets.div(2).add(1)
+          user1previewWithdrawAssets.add(1)
         )
     })
   })


### PR DESCRIPTION
There are multiple locations in the `ERC-4626` `BaseVault` that do not conform to ERC-4626
specifications:
- `previewWithdraw` does not include withdrawal fees
- `maxDeposit` does not return 0 when deposits are disabled
- `maxMint` does not return 0 when withdrawals are disabled
- `maxWithdraw` does not return 0 when withdrawals are disabled

Consider correcting the above issues to meet the `ERC-4626` specifications, allowing future vault developers to expect certain protocol behaviors.