### PR TITLE
[OZ#2: N-06] Non-explicit imports are used

### DIFF
--- a/contracts/configuration/ConfigurationManager.sol
+++ b/contracts/configuration/ConfigurationManager.sol
@@ -2,8 +2,8 @@
 
 pragma solidity 0.8.17;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "../interfaces/IConfigurationManager.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { IConfigurationManager } from "../interfaces/IConfigurationManager.sol";
 
 /**
  * @title ConfigurationManager


### PR DESCRIPTION
Non-explicit imports are used inside the codebase, which reduces code readability and could lead to conflicts between names defined locally and the ones imported. This is especially important if many contracts are defined within the same Solidity files or the inheritance chains are long.

Within `ConfigurationManager` , global imports are being used. For instance: 

- Line 5 in ConfigurationManager
- Line 6 in ConfigurationManager

Following the principle that clearer code is better code, consider using named import syntax
`( import {A, B, C} from "X" )` to explicitly declare which contracts are being imported.