### PR TITLE
[OZ#2: L-06] The sharePrice function should not revert

### DIFF
--- a/contracts/vaults/STETHVault.sol
+++ b/contracts/vaults/STETHVault.sol
@@ -73,9 +73,12 @@ contract STETHVault is BaseVault {
     /**
      * @notice Return the stETH price per share
      * @dev Each share is considered to be 10^(assets.decimals())
+     * The share price represents the amount of stETH needed to mint one vault share. When the number of vault
+     * shares that has been minted thus far is zero, the share price should simply be the ratio of the
+     * underlying asset's decimals to the vault's decimals.
      */
     function sharePrice() external view returns (uint256) {
-        return totalAssets().mulDiv(10**sharePriceDecimals, totalSupply(), Math.Rounding.Down);
+        return convertToAssets(10**sharePriceDecimals);
     }
 
     /**

--- a/test/vaults/STETHVault.ts
+++ b/test/vaults/STETHVault.ts
@@ -204,8 +204,8 @@ describe('STETHVault', () => {
       expect(totalSupply).to.be.eq(0)
       const initialSharePrice = await vault.sharePrice()
       expect(initialSharePrice).to.be.eq(BigNumber.from('10').pow(sharePriceDecimals))
-      
     })
+    
     it('maxWithdraw and withdraw should match', async () => {
       const assets = ethers.utils.parseEther('100')
       const user0Deposit = assets.mul(2)

--- a/test/vaults/STETHVault.ts
+++ b/test/vaults/STETHVault.ts
@@ -198,6 +198,14 @@ describe('STETHVault', () => {
   })
 
   describe('Reading functions', () => {
+    it('sharePrice should not revert in the case of 0 totalSupply', async () => {
+      const sharePriceDecimals = await vault.sharePriceDecimals()
+      const totalSupply = await vault.totalSupply()
+      expect(totalSupply).to.be.eq(0)
+      const initialSharePrice = await vault.sharePrice()
+      expect(initialSharePrice).to.be.eq(BigNumber.from('10').pow(sharePriceDecimals))
+      
+    })
     it('maxWithdraw and withdraw should match', async () => {
       const assets = ethers.utils.parseEther('100')
       const user0Deposit = assets.mul(2)


### PR DESCRIPTION
The `sharePrice` function in the STETHVault contract calculates the amount of stETH needed in order to mint one vault share. However, the calculation does not take into account that `totalSupply` can return zero when no deposits have been made to the vault and therefore no vault shares have been minted. Consequently, when the `totalSupply` function returns zero the `mulDiv` operation will revert.

Consider calling `convertToAssets(10**sharePriceDecimals)` in the `sharePrice` function instead of using the manual calculation as `convertToAssets` handles the zero shares edge case.