### PR TITLE
[OZ#2: N-03]: Lack of indexed parameters

### DIFF
--- a/abi/ConfigurationManager.json
+++ b/abi/ConfigurationManager.json
@@ -77,7 +77,7 @@
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "newVault",
         "type": "address"

--- a/abi/IConfigurationManager.json
+++ b/abi/IConfigurationManager.json
@@ -58,7 +58,7 @@
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "newVault",
         "type": "address"

--- a/contracts/interfaces/IConfigurationManager.sol
+++ b/contracts/interfaces/IConfigurationManager.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.17;
 interface IConfigurationManager {
     event SetCap(address indexed target, uint256 value);
     event ParameterSet(address indexed target, bytes32 indexed name, uint256 value);
-    event VaultAllowanceSet(address indexed oldVault, address newVault);
+    event VaultAllowanceSet(address indexed oldVault, address indexed newVault);
 
     error ConfigurationManager__TargetCannotBeTheZeroAddress();
 


### PR DESCRIPTION
The `VaultAllowanceSet` event in `IConigurationManager` does not have the
`newVault` parameter indexed.

Consider indexing event parameters to avoid hindering the task of off-chain services searching
and filtering for specific events.