### PR TITLE
[OZ#2: N-07] Use of uint32 for round timestamp limits vault lifetime

### DIFF
--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -28,7 +28,7 @@ interface IVault is IERC4626, IERC20Permit {
         uint256 processedDeposits;
         uint256 totalIdleAssets;
         uint32 currentRoundId;
-        uint32 lastEndRoundTimestamp;
+        uint40 lastEndRoundTimestamp;
         bool isProcessingDeposits;
     }
 

--- a/contracts/vaults/BaseVault.sol
+++ b/contracts/vaults/BaseVault.sol
@@ -60,7 +60,7 @@ abstract contract BaseVault is IVault, ERC20Permit, ERC4626, Capped {
 
         // Vault starts in `start` state
         emit RoundStarted(vaultState.currentRoundId, 0);
-        vaultState.lastEndRoundTimestamp = uint32(block.timestamp);
+        vaultState.lastEndRoundTimestamp = uint40(block.timestamp);
 
         MIN_INITIAL_ASSETS = 10**uint256(asset_.decimals());
     }
@@ -308,7 +308,7 @@ abstract contract BaseVault is IVault, ERC20Permit, ERC4626, Capped {
 
         vaultState.isProcessingDeposits = true;
         _afterRoundEnd();
-        vaultState.lastEndRoundTimestamp = uint32(block.timestamp);
+        vaultState.lastEndRoundTimestamp = uint40(block.timestamp);
 
         emit RoundEnded(vaultState.currentRoundId);
 


### PR DESCRIPTION
Closes #112 