### PR TITLE
No need for passing a newVault in Migrations

### DIFF
--- a/abi/BaseVault.json
+++ b/abi/BaseVault.json
@@ -848,13 +848,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "contract IVault",
-        "name": "newVault",
-        "type": "address"
-      }
-    ],
+    "inputs": [],
     "name": "migrate",
     "outputs": [],
     "stateMutability": "nonpayable",

--- a/abi/ConfigurationManager.json
+++ b/abi/ConfigurationManager.json
@@ -154,19 +154,14 @@
         "internalType": "address",
         "name": "oldVault",
         "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "newVault",
-        "type": "address"
       }
     ],
-    "name": "isVaultMigrationAllowed",
+    "name": "getVaultMigration",
     "outputs": [
       {
-        "internalType": "bool",
+        "internalType": "address",
         "name": "",
-        "type": "bool"
+        "type": "address"
       }
     ],
     "stateMutability": "view",

--- a/abi/IConfigurationManager.json
+++ b/abi/IConfigurationManager.json
@@ -135,19 +135,14 @@
         "internalType": "address",
         "name": "oldVault",
         "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "newVault",
-        "type": "address"
       }
     ],
-    "name": "isVaultMigrationAllowed",
+    "name": "getVaultMigration",
     "outputs": [
       {
-        "internalType": "bool",
+        "internalType": "address",
         "name": "",
-        "type": "bool"
+        "type": "address"
       }
     ],
     "stateMutability": "view",

--- a/abi/Migration.json
+++ b/abi/Migration.json
@@ -36,11 +36,6 @@
         "type": "address"
       },
       {
-        "internalType": "contract IVault",
-        "name": "to",
-        "type": "address"
-      },
-      {
         "internalType": "uint256",
         "name": "shares",
         "type": "uint256"
@@ -62,11 +57,6 @@
       {
         "internalType": "contract IVault",
         "name": "from",
-        "type": "address"
-      },
-      {
-        "internalType": "contract IVault",
-        "name": "to",
         "type": "address"
       },
       {

--- a/abi/PrincipalProtectedMock.json
+++ b/abi/PrincipalProtectedMock.json
@@ -1012,13 +1012,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "contract IVault",
-        "name": "newVault",
-        "type": "address"
-      }
-    ],
+    "inputs": [],
     "name": "migrate",
     "outputs": [],
     "stateMutability": "nonpayable",

--- a/abi/STETHVault.json
+++ b/abi/STETHVault.json
@@ -1012,13 +1012,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "contract IVault",
-        "name": "newVault",
-        "type": "address"
-      }
-    ],
+    "inputs": [],
     "name": "migrate",
     "outputs": [],
     "stateMutability": "nonpayable",

--- a/contracts/configuration/ConfigurationManager.sol
+++ b/contracts/configuration/ConfigurationManager.sol
@@ -69,7 +69,7 @@ contract ConfigurationManager is IConfigurationManager, Ownable {
     /**
      * @inheritdoc IConfigurationManager
      */
-    function isVaultMigrationAllowed(address oldVault, address newVault) external view override returns (bool) {
-        return _allowedVaults[oldVault] == newVault;
+    function getVaultMigration(address oldVault) external view override returns (address) {
+        return _allowedVaults[oldVault];
     }
 }

--- a/contracts/interfaces/IConfigurationManager.sol
+++ b/contracts/interfaces/IConfigurationManager.sol
@@ -62,9 +62,8 @@ interface IConfigurationManager {
     function setVaultMigration(address oldVault, address newVault) external;
 
     /**
-     * @notice Returns if the migration for a vault is allowed.
+     * @notice Returns the new Vault address.
      * @param oldVault The current vault address
-     * @param newVault The vault where assets are going to be migrated to
      */
-    function isVaultMigrationAllowed(address oldVault, address newVault) external view returns (bool);
+    function getVaultMigration(address oldVault) external view returns (address);
 }

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -146,9 +146,10 @@ interface IVault is IERC4626, IERC20Permit {
     function refund() external returns (uint256 assets);
 
     /**
-     * @notice Migrate assets from this vault to `newVault`.
+     * @notice Migrate assets from this vault to the next vault.
+     * @dev The `newVault` will be assigned by the ConfigurationManager
      */
-    function migrate(IVault newVault) external;
+    function migrate() external;
 
     /**
      * @notice Handle migrated assets.

--- a/contracts/proxy/Migration.sol
+++ b/contracts/proxy/Migration.sol
@@ -30,16 +30,13 @@ contract Migration {
      * It will withdraw from the old vault and it will deposit into the new vault
      * @dev The new shares only will be available after the process deposit of the new vault
      * @param from origin vault (old Vault) from the liquidity will be migrated
-     * @param to destination vault (new Vault) to deposit
      * @param shares amount of shares to withdraw from the origin vault (from)
      * @return uint256 shares' amount returned by the new vault contract
      */
-    function migrate(
-        IVault from,
-        IVault to,
-        uint256 shares
-    ) external returns (uint256) {
-        if (!configuration.isVaultMigrationAllowed(address(from), address(to))) {
+    function migrate(IVault from, uint256 shares) external returns (uint256) {
+        IVault to = IVault(configuration.getVaultMigration(address(from)));
+
+        if (to == IVault(address(0))) {
             revert Migration__MigrationNotAllowed();
         }
 
@@ -55,7 +52,6 @@ contract Migration {
      * @notice migrateWithPermit liquidity from an old vault to a new vault
      * * It will withdraw from the old vault and it will deposit into the new vault
      * @param from origin vault (old Vault) from where the liquidity will be migrated
-     * @param to destination vault (new Vault) to deposit
      * @param shares amount of shares to withdraw from the origin vault (from)
      * @param deadline deadline that this transaction will be valid
      * @param v recovery id
@@ -65,14 +61,15 @@ contract Migration {
      */
     function migrateWithPermit(
         IVault from,
-        IVault to,
         uint256 shares,
         uint256 deadline,
         uint8 v,
         bytes32 r,
         bytes32 s
     ) external returns (uint256) {
-        if (!configuration.isVaultMigrationAllowed(address(from), address(to))) {
+        IVault to = IVault(configuration.getVaultMigration(address(from)));
+
+        if (to == IVault(address(0))) {
             revert Migration__MigrationNotAllowed();
         }
 

--- a/contracts/vaults/BaseVault.sol
+++ b/contracts/vaults/BaseVault.sol
@@ -341,8 +341,10 @@ abstract contract BaseVault is IVault, ERC20Permit, ERC4626, Capped {
     /**
      * @inheritdoc IVault
      */
-    function migrate(IVault newVault) external override {
-        if (!configuration.isVaultMigrationAllowed(address(this), address(newVault))) {
+    function migrate() external override {
+        IVault newVault = IVault(configuration.getVaultMigration(address(this)));
+
+        if (newVault == IVault(address(0))) {
             revert IVault__MigrationNotAllowed();
         }
 
@@ -361,7 +363,9 @@ abstract contract BaseVault is IVault, ERC20Permit, ERC4626, Capped {
      * @inheritdoc IVault
      */
     function handleMigration(uint256 assets, address receiver) external override returns (uint256) {
-        if (!configuration.isVaultMigrationAllowed(msg.sender, address(this))) {
+        IVault newVault = IVault(configuration.getVaultMigration(msg.sender));
+
+        if (address(newVault) != address(this)) {
             revert IVault__MigrationNotAllowed();
         }
 

--- a/test/proxy/Migration.ts
+++ b/test/proxy/Migration.ts
@@ -127,7 +127,7 @@ describe('Migration', () => {
 
     // Execute migration
     await vaultFrom.connect(user1).approve(migration.address, ethers.constants.MaxUint256)
-    await migration.connect(user1).migrate(vaultFrom.address, vaultTo.address, await vaultFrom.balanceOf(user1.address))
+    await migration.connect(user1).migrate(vaultFrom.address, await vaultFrom.balanceOf(user1.address))
 
     expect(await vaultFrom.totalAssets()).to.be.closeTo(vaultFromTotalAssets.sub(user1Withdrawable), 1)
     expect(await asset.balanceOf(migration.address)).to.be.closeTo(BigNumber.from('0'), 1)
@@ -160,7 +160,6 @@ describe('Migration', () => {
     )
     await migration.connect(userPermit).migrateWithPermit(
       vaultFrom.address,
-      vaultTo.address,
       shares,
       permit.deadline,
       permit.v,
@@ -204,7 +203,6 @@ describe('Migration', () => {
     )
     migrationTx = migration.connect(userPermit).migrateWithPermit(
       vaultFrom.address,
-      vaultTo.address,
       shares,
       permit.deadline,
       permit.v,
@@ -217,7 +215,6 @@ describe('Migration', () => {
     await vaultFrom.connect(user1).approve(migration.address, ethers.constants.MaxUint256)
     migrationTx = migration.connect(user1).migrate(
       vaultFrom.address,
-      vaultTo.address,
       await vaultFrom.balanceOf(user1.address)
     )
 

--- a/test/vaults/BaseVault.ts
+++ b/test/vaults/BaseVault.ts
@@ -824,7 +824,7 @@ describe('BaseVault', () => {
       expect(await vault.assetsOf(user0.address)).to.be.equal(assets)
       expect(await newVault.idleAssetsOf(user0.address)).to.be.equal(0)
 
-      const migrationTx = vault.connect(user0).migrate(newVault.address)
+      const migrationTx = vault.connect(user0).migrate()
       await expect(migrationTx)
         .to.emit(vault, 'Migrated')
         .withArgs(user0.address, vault.address, newVault.address, feeExcluded(assets), shares)
@@ -833,7 +833,7 @@ describe('BaseVault', () => {
       expect(await newVault.idleAssetsOf(user0.address)).to.be.equal(feeExcluded(assets))
     })
 
-    it('should not migrate to disallowed vaults', async () => {
+    it('should not migrate if a vault was not assigned', async () => {
       const assets = ethers.utils.parseEther('100')
 
       await asset.connect(user0).mint(assets)
@@ -842,14 +842,7 @@ describe('BaseVault', () => {
       await vault.connect(vaultController).processQueuedDeposits([user0.address])
       await vault.connect(vaultController).startRound()
 
-      const Vault = await ethers.getContractFactory('YieldVaultMock')
-      const newVault = await Vault.deploy(
-        configuration.address,
-        asset.address,
-        yieldSource.address
-      )
-
-      const migrationTx = vault.connect(user0).migrate(newVault.address)
+      const migrationTx = vault.connect(user0).migrate()
       await expect(migrationTx)
         .to.be.revertedWithCustomError(vault, 'IVault__MigrationNotAllowed')
     })


### PR DESCRIPTION
Instead of checking for zero addresses as the issue #125 recommended, we are forcing the destination vault to be store in the ConfigurationManager. This may closes #125 