### PR TITLE
[OZ#2: M-05]: Non-standard ERC-4626 vault functionality

### DIFF
--- a/contracts/vaults/BaseVault.sol
+++ b/contracts/vaults/BaseVault.sol
@@ -214,25 +214,49 @@ abstract contract BaseVault is IVault, ERC20Permit, ERC4626, Capped {
      * @inheritdoc IERC4626
      */
     function maxDeposit(address) public view virtual override(ERC4626, IERC4626) returns (uint256) {
-        uint256 _availableCap = availableCap();
-        if (_availableCap != type(uint256).max) {
-            return previewMint(_availableCap);
+        if (vaultState.isProcessingDeposits) {
+            return 0;
+        } else {
+            uint256 _availableCap = availableCap();
+
+            if (_availableCap != type(uint256).max) {
+                return previewMint(_availableCap);
+            }
+            return _availableCap;
         }
-        return _availableCap;
     }
 
     /**
      * @inheritdoc IERC4626
      */
     function maxMint(address) public view override(ERC4626, IERC4626) returns (uint256) {
-        return availableCap();
+        if (vaultState.isProcessingDeposits) {
+            return 0;
+        } else {
+            return availableCap();
+        }
     }
 
     /**
      * @inheritdoc IERC4626
      */
     function maxWithdraw(address owner) public view override(ERC4626, IERC4626) returns (uint256) {
-        return previewRedeem(balanceOf(owner));
+        if (vaultState.isProcessingDeposits) {
+            return 0;
+        } else {
+            return previewRedeem(balanceOf(owner));
+        }
+    }
+
+    /**
+     * @inheritdoc IERC4626
+     */
+    function maxRedeem(address owner) public view override(ERC4626, IERC4626) returns (uint256) {
+        if (vaultState.isProcessingDeposits) {
+            return 0;
+        } else {
+            return balanceOf(owner);
+        }
     }
 
     /**

--- a/test/vaults/BaseVault.ts
+++ b/test/vaults/BaseVault.ts
@@ -97,6 +97,20 @@ describe('BaseVault', () => {
       expect(user1maxWithdraw).to.be.closeTo(user1AfterBalance, 1)
     })
 
+    it('should return 0 in maxWithdraw when vault is unable to perform withdraw', async () => {
+      const assets = ethers.utils.parseEther('100')
+      const user0Deposit = assets.mul(2)
+      const user1Deposit = assets
+
+      await asset.connect(user0).mint(user0Deposit)
+      await asset.connect(user1).mint(user1Deposit)
+      // Round 0
+      await vault.connect(user0).deposit(user0Deposit, user0.address)
+      await vault.connect(user1).deposit(user1Deposit, user1.address)
+      await vault.connect(vaultController).endRound()
+      expect(await vault.maxWithdraw(user0.address)).to.be.eq(0)
+    })
+
     it('maxRedeem and withdraw should match', async () => {
       const assets = ethers.utils.parseEther('100')
       const user0Deposit = assets.mul(2)
@@ -121,6 +135,48 @@ describe('BaseVault', () => {
 
       expect(user0maxRedeem).to.be.equal(user0maxShares)
       expect(user1maxRedeem).to.be.equal(user1maxShares)
+    })
+
+    it('should return 0 in maxRedeem when vault is unable to perform redeem', async () => {
+      const assets = ethers.utils.parseEther('100')
+      const user0Deposit = assets.mul(2)
+      const user1Deposit = assets
+
+      await asset.connect(user0).mint(user0Deposit)
+      await asset.connect(user1).mint(user1Deposit)
+      // Round 0
+      await vault.connect(user0).deposit(user0Deposit, user0.address)
+      await vault.connect(user1).deposit(user1Deposit, user1.address)
+      await vault.connect(vaultController).endRound()
+      expect(await vault.maxRedeem(user0.address)).to.be.eq(0)
+    })
+
+    it('should return 0 in maxMint when vault is unable to perform mint', async () => {
+      const assets = ethers.utils.parseEther('100')
+      const user0Deposit = assets.mul(2)
+      const user1Deposit = assets
+
+      await asset.connect(user0).mint(user0Deposit)
+      await asset.connect(user1).mint(user1Deposit)
+      // Round 0
+      await vault.connect(user0).deposit(user0Deposit, user0.address)
+      await vault.connect(user1).deposit(user1Deposit, user1.address)
+      await vault.connect(vaultController).endRound()
+      expect(await vault.maxMint(user0.address)).to.be.eq(0)
+    })
+
+    it('should return 0 in maxDeposit when vault is unable to perform deposit', async () => {
+      const assets = ethers.utils.parseEther('100')
+      const user0Deposit = assets.mul(2)
+      const user1Deposit = assets
+
+      await asset.connect(user0).mint(user0Deposit)
+      await asset.connect(user1).mint(user1Deposit)
+      // Round 0
+      await vault.connect(user0).deposit(user0Deposit, user0.address)
+      await vault.connect(user1).deposit(user1Deposit, user1.address)
+      await vault.connect(vaultController).endRound()
+      expect(await vault.maxDeposit(user0.address)).to.be.eq(0)
     })
 
     it('both maxDeposit and maxMint should be MAX_UINT', async () => {
@@ -153,6 +209,7 @@ describe('BaseVault', () => {
 
       expect(withdrawnBalance).to.be.equal(user0previewShares)
     })
+
     it('previewRedeem and withdraw should match', async () => {
       const assets = ethers.utils.parseEther('100')
       const user0Deposit = assets.mul(2)

--- a/test/vaults/PrincipalProtectedMock.ts
+++ b/test/vaults/PrincipalProtectedMock.ts
@@ -517,30 +517,16 @@ describe('PrincipalProtectedMock', () => {
     // console.log('----------------')
 
     await vault.connect(vaultController).endRound()
+    await vault.connect(vaultController).startRound()
 
     const user0Moment4maxWithdraw = await vault.maxWithdraw(user0.address)
     const user1Moment4maxWithdraw = await vault.maxWithdraw(user1.address)
     const user2Moment4maxWithdraw = await vault.maxWithdraw(user2.address)
 
-    // console.log('MOMENT 4 - Should have less amount than 3 -> transferred some funds to investor')
-    expect(user0Moment4maxWithdraw).to.be.lte(user0Moment3maxWithdraw)
-    expect(user1Moment4maxWithdraw).to.be.lte(user1Moment3maxWithdraw)
-    expect(user2Moment4maxWithdraw).to.be.lte(user2Moment3maxWithdraw)
-    // console.log((await vault.maxWithdraw(user0.address)).toString())
-    // console.log((await vault.maxWithdraw(user1.address)).toString())
-    // console.log((await vault.maxWithdraw(user2.address)).toString())
-    // console.log('----------------')
-
-    await vault.connect(vaultController).startRound()
-
-    const user0Moment5maxWithdraw = await vault.maxWithdraw(user0.address)
-    const user1Moment5maxWithdraw = await vault.maxWithdraw(user1.address)
-    const user2Moment5maxWithdraw = await vault.maxWithdraw(user2.address)
-
-    // console.log('MOMENT 5 - Should have the same amount as MOMENT 4')
-    expect(user0Moment5maxWithdraw).to.be.eq(user0Moment4maxWithdraw)
-    expect(user1Moment5maxWithdraw).to.be.eq(user1Moment4maxWithdraw)
-    expect(user2Moment5maxWithdraw).to.be.eq(user2Moment4maxWithdraw)
+    // console.log('MOMENT 4 - Should have the lower amount as MOMENT 3 - due to yield comsuption in the endRound')
+    expect(user0Moment4maxWithdraw).to.be.lt(user0Moment3maxWithdraw)
+    expect(user1Moment4maxWithdraw).to.be.lt(user1Moment3maxWithdraw)
+    expect(user2Moment4maxWithdraw).to.be.lt(user2Moment3maxWithdraw)
 
     // console.log((await vault.maxWithdraw(user0.address)).toString())
     // console.log((await vault.maxWithdraw(user1.address)).toString())
@@ -549,11 +535,26 @@ describe('PrincipalProtectedMock', () => {
 
     await investor.buyOptionsWithYield()
 
+    const user0Moment5maxWithdraw = await vault.maxWithdraw(user0.address)
+    const user1Moment5maxWithdraw = await vault.maxWithdraw(user1.address)
+    const user2Moment5maxWithdraw = await vault.maxWithdraw(user2.address)
+
+    // console.log('MOMENT 6 - Should have the same amount as MOMENT 5 and 4')
+    expect(user0Moment5maxWithdraw).to.be.eq(user0Moment4maxWithdraw)
+    expect(user1Moment5maxWithdraw).to.be.eq(user1Moment4maxWithdraw)
+    expect(user2Moment5maxWithdraw).to.be.eq(user2Moment4maxWithdraw)
+    // console.log((await vault.maxWithdraw(user0.address)).toString())
+    // console.log((await vault.maxWithdraw(user1.address)).toString())
+    // console.log((await vault.maxWithdraw(user2.address)).toString())
+    // console.log('----------------')
+
+    await investor.generatePremium(ethers.utils.parseEther('600'))
+
     const user0Moment6maxWithdraw = await vault.maxWithdraw(user0.address)
     const user1Moment6maxWithdraw = await vault.maxWithdraw(user1.address)
     const user2Moment6maxWithdraw = await vault.maxWithdraw(user2.address)
 
-    // console.log('MOMENT 6 - Should have the same amount as MOMENT 5 and 4')
+    // console.log('MOMENT 7 - Should have same amount as MOMENTS 6, 5 and 4')
     expect(user0Moment6maxWithdraw).to.be.eq(user0Moment5maxWithdraw)
     expect(user1Moment6maxWithdraw).to.be.eq(user1Moment5maxWithdraw)
     expect(user2Moment6maxWithdraw).to.be.eq(user2Moment5maxWithdraw)
@@ -562,31 +563,16 @@ describe('PrincipalProtectedMock', () => {
     // console.log((await vault.maxWithdraw(user2.address)).toString())
     // console.log('----------------')
 
-    await investor.generatePremium(ethers.utils.parseEther('600'))
+    await vault.connect(vaultController).endRound()
 
     const user0Moment7maxWithdraw = await vault.maxWithdraw(user0.address)
     const user1Moment7maxWithdraw = await vault.maxWithdraw(user1.address)
     const user2Moment7maxWithdraw = await vault.maxWithdraw(user2.address)
 
-    // console.log('MOMENT 7 - Should have same amount as MOMENTS 6, 5 and 4')
-    expect(user0Moment7maxWithdraw).to.be.eq(user0Moment6maxWithdraw)
-    expect(user1Moment7maxWithdraw).to.be.eq(user1Moment6maxWithdraw)
-    expect(user2Moment7maxWithdraw).to.be.eq(user2Moment6maxWithdraw)
-    // console.log((await vault.maxWithdraw(user0.address)).toString())
-    // console.log((await vault.maxWithdraw(user1.address)).toString())
-    // console.log((await vault.maxWithdraw(user2.address)).toString())
-    // console.log('----------------')
-
-    await vault.connect(vaultController).endRound()
-
-    const user0Moment8maxWithdraw = await vault.maxWithdraw(user0.address)
-    const user1Moment8maxWithdraw = await vault.maxWithdraw(user1.address)
-    const user2Moment8maxWithdraw = await vault.maxWithdraw(user2.address)
-
-    // console.log('MOMENT 8 - Should have more amount than MOMENT 7')
-    expect(user0Moment8maxWithdraw).to.be.gt(user0Moment7maxWithdraw)
-    expect(user1Moment8maxWithdraw).to.be.gt(user1Moment7maxWithdraw)
-    expect(user2Moment8maxWithdraw).to.be.gt(user2Moment7maxWithdraw)
+    // console.log('MOMENT 7 - Should be equal to 0 (compliant to ERC4626))
+    expect(user0Moment7maxWithdraw).to.be.eq(0)
+    expect(user1Moment7maxWithdraw).to.be.eq(0)
+    expect(user2Moment7maxWithdraw).to.be.eq(0)
     // console.log((await vault.maxWithdraw(user0.address)).toString())
     // console.log((await vault.maxWithdraw(user1.address)).toString())
     // console.log((await vault.maxWithdraw(user2.address)).toString())
@@ -594,18 +580,18 @@ describe('PrincipalProtectedMock', () => {
 
     await vault.connect(vaultController).startRound()
 
-    const user0Moment9maxWithdraw = await vault.maxWithdraw(user0.address)
-    const user1Moment9maxWithdraw = await vault.maxWithdraw(user1.address)
-    const user2Moment9maxWithdraw = await vault.maxWithdraw(user2.address)
-    // console.log('MOMENT 9 - Should have the same amount as MOMENT 8')
+    const user0Moment8maxWithdraw = await vault.maxWithdraw(user0.address)
+    const user1Moment8maxWithdraw = await vault.maxWithdraw(user1.address)
+    const user2Moment8maxWithdraw = await vault.maxWithdraw(user2.address)
+    // console.log('MOMENT 8 - Should have the higher amount as MOMENT 6 - due to premium > yield earned')
     // console.log((await vault.maxWithdraw(user0.address)).toString())
     // console.log((await vault.maxWithdraw(user1.address)).toString())
     // console.log((await vault.maxWithdraw(user2.address)).toString())
     // console.log('----------------')
 
-    expect(user0Moment9maxWithdraw).to.be.eq(user0Moment8maxWithdraw)
-    expect(user1Moment9maxWithdraw).to.be.eq(user1Moment8maxWithdraw)
-    expect(user2Moment9maxWithdraw).to.be.eq(user2Moment8maxWithdraw)
+    expect(user0Moment8maxWithdraw).to.be.gt(user0Moment6maxWithdraw)
+    expect(user1Moment8maxWithdraw).to.be.gt(user1Moment6maxWithdraw)
+    expect(user2Moment8maxWithdraw).to.be.gt(user2Moment6maxWithdraw)
 
     const sharesAmount0 = await vault.balanceOf(user0.address)
     const sharesAmount1 = await vault.balanceOf(user1.address)
@@ -615,14 +601,14 @@ describe('PrincipalProtectedMock', () => {
     await vault.connect(user1).redeem(sharesAmount1, user1.address, user1.address)
     await vault.connect(user2).redeem(sharesAmount2, user2.address, user2.address)
 
-    const user0Moment10Balance = await asset.balanceOf(user0.address)
-    const user1Moment10Balance = await asset.balanceOf(user1.address)
-    const user2Moment10Balance = await asset.balanceOf(user2.address)
+    const user0Moment9Balance = await asset.balanceOf(user0.address)
+    const user1Moment9Balance = await asset.balanceOf(user1.address)
+    const user2Moment9Balance = await asset.balanceOf(user2.address)
 
-    // console.log('MOMENT 10 - Should have the same amount as 8 and 9 minus fees')
-    expect(user0Moment10Balance).to.be.lte(user0Moment9maxWithdraw)
-    expect(user1Moment10Balance).to.be.lte(user1Moment9maxWithdraw)
-    expect(user2Moment10Balance.sub(1)).to.be.lte(user2Moment9maxWithdraw)
+    // console.log('MOMENT 9 - Should have the same amount as 8 minus fees')
+    expect(user0Moment9Balance).to.be.lte(user0Moment8maxWithdraw)
+    expect(user1Moment9Balance).to.be.lte(user1Moment8maxWithdraw)
+    expect(user2Moment9Balance.sub(1)).to.be.lte(user2Moment8maxWithdraw)
 
     // console.log((await asset.balanceOf(user0.address)).toString())
     // console.log((await asset.balanceOf(user1.address)).toString())

--- a/test/vaults/STETHVault.ts
+++ b/test/vaults/STETHVault.ts
@@ -245,6 +245,18 @@ describe('STETHVault', () => {
       expect(user1BalanceOf).to.be.equal('0')
     })
 
+    it('should return 0 in maxWithdraw when vault is unable to perform withdraw', async () => {
+      const assets = ethers.utils.parseEther('100')
+      const user0Deposit = assets.mul(2)
+      const user1Deposit = assets
+
+      await vault.connect(user0).deposit(user0Deposit, user0.address)
+      await vault.connect(user1).deposit(user1Deposit, user1.address)
+      await vault.connect(vaultController).endRound()
+
+      expect(await vault.maxWithdraw(user0.address)).to.be.eq(0)
+    })
+
     it('maxRedeem and withdraw should match', async () => {
       const assets = ethers.utils.parseEther('100')
       const user0Deposit = assets.mul(2)
@@ -266,6 +278,42 @@ describe('STETHVault', () => {
 
       expect(user0maxRedeem).to.be.equal(user0maxShares)
       expect(user1maxRedeem).to.be.equal(user1maxShares)
+    })
+
+    it('should return 0 in maxRedeem when vault is unable to perform redeem', async () => {
+      const assets = ethers.utils.parseEther('100')
+      const user0Deposit = assets.mul(2)
+      const user1Deposit = assets
+
+      await vault.connect(user0).deposit(user0Deposit, user0.address)
+      await vault.connect(user1).deposit(user1Deposit, user1.address)
+      await vault.connect(vaultController).endRound()
+
+      expect(await vault.maxRedeem(user0.address)).to.be.eq(0)
+    })
+
+    it('should return 0 in maxMint when vault is unable to perform mint', async () => {
+      const assets = ethers.utils.parseEther('100')
+      const user0Deposit = assets.mul(2)
+      const user1Deposit = assets
+
+      await vault.connect(user0).deposit(user0Deposit, user0.address)
+      await vault.connect(user1).deposit(user1Deposit, user1.address)
+      await vault.connect(vaultController).endRound()
+
+      expect(await vault.maxMint(user0.address)).to.be.eq(0)
+    })
+
+    it('should return 0 in maxDeposit when vault is unable to perform deposit', async () => {
+      const assets = ethers.utils.parseEther('100')
+      const user0Deposit = assets.mul(2)
+      const user1Deposit = assets
+
+      await vault.connect(user0).deposit(user0Deposit, user0.address)
+      await vault.connect(user1).deposit(user1Deposit, user1.address)
+      await vault.connect(vaultController).endRound()
+
+      expect(await vault.maxDeposit(user0.address)).to.be.eq(0)
     })
 
     it('assetsOf should match in a mixed case', async () => {
@@ -831,9 +879,9 @@ describe('STETHVault', () => {
     const user2Moment4maxWithdraw = await vault.maxWithdraw(user2.address)
 
     // console.log(‘MOMENT 4 - Should have less amount than 3 -> transferred some funds to investor’)
-    expect(user0Moment4maxWithdraw).to.be.lte(user0Moment3maxWithdraw)
-    expect(user1Moment4maxWithdraw).to.be.lte(user1Moment3maxWithdraw)
-    expect(user2Moment4maxWithdraw).to.be.lte(user2Moment3maxWithdraw)
+    expect(user0Moment4maxWithdraw).to.be.eq(0)
+    expect(user1Moment4maxWithdraw).to.be.eq(0)
+    expect(user2Moment4maxWithdraw).to.be.eq(0)
 
     await vault.connect(vaultController).startRound()
 
@@ -841,10 +889,10 @@ describe('STETHVault', () => {
     const user1Moment5maxWithdraw = await vault.maxWithdraw(user1.address)
     const user2Moment5maxWithdraw = await vault.maxWithdraw(user2.address)
 
-    // console.log(‘MOMENT 5 - Should have the same amount as MOMENT 4’)
-    expect(user0Moment5maxWithdraw).to.be.closeTo(user0Moment4maxWithdraw, 1)
-    expect(user1Moment5maxWithdraw).to.be.closeTo(user1Moment4maxWithdraw, 1)
-    expect(user2Moment5maxWithdraw).to.be.closeTo(user2Moment4maxWithdraw, 1)
+    // console.log(‘MOMENT 5 - Should have less amount than 3 -> transferred some funds to investor’)
+    expect(user0Moment5maxWithdraw).to.be.lt(user0Moment3maxWithdraw)
+    expect(user1Moment5maxWithdraw).to.be.lt(user1Moment3maxWithdraw)
+    expect(user2Moment5maxWithdraw).to.be.lt(user2Moment3maxWithdraw)
 
     await investor.buyOptionsWithYield()
 
@@ -875,10 +923,10 @@ describe('STETHVault', () => {
     const user1Moment8maxWithdraw = await vault.maxWithdraw(user1.address)
     const user2Moment8maxWithdraw = await vault.maxWithdraw(user2.address)
 
-    // console.log(‘MOMENT 8 - Should have more amount than MOMENT 7’)
-    expect(user0Moment8maxWithdraw).to.be.gte(user0Moment7maxWithdraw)
-    expect(user1Moment8maxWithdraw).to.be.gte(user1Moment7maxWithdraw)
-    expect(user2Moment8maxWithdraw).to.be.gte(user2Moment7maxWithdraw)
+    // console.log(‘MOMENT 8 - Should be equal to 0 -> Compliant to ERC4626’)
+    expect(user0Moment8maxWithdraw).to.be.eq(0)
+    expect(user1Moment8maxWithdraw).to.be.eq(0)
+    expect(user2Moment8maxWithdraw).to.be.eq(0)
 
     await vault.connect(vaultController).startRound()
 
@@ -886,10 +934,10 @@ describe('STETHVault', () => {
     const user1Moment9maxWithdraw = await vault.maxWithdraw(user1.address)
     const user2Moment9maxWithdraw = await vault.maxWithdraw(user2.address)
 
-    // console.log(‘MOMENT 9 - Should have the same amount as MOMENT 8’)
-    expect(user0Moment9maxWithdraw).to.be.closeTo(user0Moment8maxWithdraw, 1)
-    expect(user1Moment9maxWithdraw).to.be.closeTo(user1Moment8maxWithdraw, 1)
-    expect(user2Moment9maxWithdraw).to.be.closeTo(user2Moment8maxWithdraw, 1)
+    // console.log(‘MOMENT 9 - Should have the larger amount as MOMENT 7 -> due the premium collected in the EndRound’)
+    expect(user0Moment9maxWithdraw).to.be.gt(user0Moment7maxWithdraw)
+    expect(user1Moment9maxWithdraw).to.be.gt(user1Moment7maxWithdraw)
+    expect(user2Moment9maxWithdraw).to.be.gt(user2Moment7maxWithdraw)
 
     const sharesAmount0 = await vault.balanceOf(user0.address)
     const sharesAmount1 = await vault.balanceOf(user1.address)


### PR DESCRIPTION
This PR dont solve completely this issue. It solves: 

-  `maxDeposit` should return 0 when deposits are disabled
- `maxMint` should return 0 when withdrawals are disabled
-  `maxWithdraw` should return 0 when withdrawals are disabled
- `maxRedeem` should return 0 when withdrawals are disabled

It not solves:
- previewWithdraw does not include withdrawal fees
- withdraw less assets than asked (because it removes the fees)