### PR TITLE
Update echidna instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ typechain
 #Hardhat files
 cache
 artifacts
+
+#Echidna files
+echidna/

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You can find the system coverage below or a detailed version here : https://cove
 
 ## Fuzzy Test
 
-You will need to install [echidna](https://github.com/crytic/echidna) separately and checkout to the `fuzzing` branch. In that branch you can run:
+You will need to install [echidna](https://github.com/crytic/echidna) separately and run:
 
 ```shell
 echidna-test test/invariants/ --contract STETHVaultInvariants --config test/invariants/config.yaml

--- a/test/invariants/config.yaml
+++ b/test/invariants/config.yaml
@@ -70,7 +70,7 @@ cryticArgs:
 # # by default, blacklist methods in filterFunctions
 # filterBlacklist: true
 # #directory to save the corpus; by default is disabled
-corpusDir: "/echidna/corpus"
+corpusDir: "echidna/corpus"
 # # constants for corpus mutations (for experimentation only)
 # mutConsts: [100, 1, 1]
 # # maximum value to send to payable functions


### PR DESCRIPTION
Update echidna instructions.

- Remove instructions regarding non-existent `fuzzying` branch
- Update corpus directory
- Add corpus directory to `.gitignore`