### PR TITLE
Fix invariant tests

### DIFF
--- a/test/invariants/STETHVaultInvariants.sol
+++ b/test/invariants/STETHVaultInvariants.sol
@@ -75,8 +75,6 @@ contract User {
 }
 
 contract STETHVaultInvariants is FuzzyAddresses {
-    using EnumerableSet for EnumerableSet.UintSet;
-
     ConfigurationManager private $configuration = new ConfigurationManager();
     STETH private $asset = new STETH();
     InvestorActorMock private $investor = new InvestorActorMock(address($asset));

--- a/test/invariants/STETHVaultInvariants.sol
+++ b/test/invariants/STETHVaultInvariants.sol
@@ -34,20 +34,38 @@ library String {
 }
 
 contract FuzzyAddresses {
-    address public constant user0 = address(0x10000);
-    address public constant user1 = address(0x20000);
-    address public constant vaultController = address(0x30000);
+    address internal constant user0 = address(0x10000);
+    address internal constant user1 = address(0x20000);
+    address internal constant vaultController = address(0x30000);
 
     function _addressIsAllowed(address to) internal returns (bool) {
         return to == user0 || to == user1 || to == vaultController;
     }
 }
 
-contract STETHVaultInvariants is STETHVault, FuzzyAddresses {
-    ConfigurationManager public $configuration = new ConfigurationManager();
-    STETH public $asset = new STETH();
-    InvestorActorMock public $investor = new InvestorActorMock(address($asset));
-    event AssertionFailed(bool);
+contract STETHVaultHarness is STETHVault {
+    constructor(
+        IConfigurationManager _configuration,
+        IERC20Metadata _asset,
+        address _investor
+    ) STETHVault(_configuration, _asset, _investor) {}
+
+    // HARNESS: changed to public from internal
+    function ___vaultState() public returns (VaultState memory) {
+        return vaultState;
+    }
+
+    // HARNESS: changed to public from internal
+    function ___convertToShares(uint256 assets, Math.Rounding rounding) public view returns (uint256 shares) {
+        return _convertToShares(assets, rounding);
+    }
+}
+
+contract STETHVaultInvariants is FuzzyAddresses {
+    ConfigurationManager private $configuration = new ConfigurationManager();
+    STETH private $asset = new STETH();
+    InvestorActorMock private $investor = new InvestorActorMock(address($asset));
+    STETHVaultHarness private vault = new STETHVaultHarness($configuration, $asset, address($investor));
 
     struct LastDeposit {
         uint256 amount;
@@ -55,43 +73,43 @@ contract STETHVaultInvariants is STETHVault, FuzzyAddresses {
         uint256 shares;
     }
 
-    mapping(address => LastDeposit) public lastDeposits;
+    mapping(address => LastDeposit) private lastDeposits;
 
-    constructor() STETHVault($configuration, $asset, address($investor)) {
-        $configuration.setParameter(address(this), "VAULT_CONTROLLER", 0x30000);
+    constructor() {
+        $configuration.setParameter(address(this), "VAULT_CONTROLLER", uint256(uint160(vaultController)));
     }
 
     function echidna_test_name() public view returns (bool) {
-        return String.equal(name(), "stETH Volatility Vault");
+        return String.equal(vault.name(), "stETH Volatility Vault");
     }
 
     function echidna_test_symbol() public returns (bool) {
-        return String.equal(symbol(), "stETHvv");
+        return String.equal(vault.symbol(), "stETHvv");
     }
 
     function echidna_test_decimals() public returns (bool) {
-        return decimals() == $asset.decimals();
+        return vault.decimals() == $asset.decimals();
     }
 
     function generateInterest(uint256 a) public {
         if (a == 0) return;
-        uint256 addInterest = (totalAssets() / a);
+        uint256 addInterest = (vault.totalAssets() / a);
         $asset.generateInterest(addInterest);
     }
 
     //  ["0x10000", "0x20000", "0x30000"]
     function echidna_sum_total_supply() public returns (bool) {
-        uint256 balanceA = balanceOf(user0);
-        uint256 balanceB = balanceOf(user1);
-        uint256 balanceC = balanceOf(vaultController);
+        uint256 balanceA = vault.balanceOf(user0);
+        uint256 balanceB = vault.balanceOf(user1);
+        uint256 balanceC = vault.balanceOf(vaultController);
 
         uint256 sumBalances = balanceA + balanceB + balanceC;
 
-        return sumBalances == totalSupply();
+        return sumBalances == vault.totalSupply();
     }
 
     function echidna_lastRoundAssets_always_greater_than_totalAssets() public returns (bool) {
-        return totalAssets() >= lastRoundAssets;
+        return vault.totalAssets() >= vault.lastRoundAssets();
     }
 
     /**
@@ -101,41 +119,41 @@ contract STETHVaultInvariants is STETHVault, FuzzyAddresses {
      */
     //
     function helpProcessQueue() public {
-        this.processQueuedDeposits(this.queuedDeposits());
+        vault.processQueuedDeposits(vault.queuedDeposits());
     }
 
-    function deposit(uint256 assets, address) public override returns (uint256 shares) {
-        uint256 createdShares = convertToShares(assets);
+    function deposit(uint256 assets, address) public returns (uint256 shares) {
+        uint256 createdShares = vault.convertToShares(assets);
         LastDeposit memory newDeposit = LastDeposit({
             amount: assets,
-            roundId: vaultState.currentRoundId,
+            roundId: vault.___vaultState().currentRoundId,
             shares: createdShares
         });
         lastDeposits[msg.sender] = newDeposit;
-        return this.deposit(assets, msg.sender);
+        return vault.deposit(assets, msg.sender);
     }
 
-    function mint(uint256 shares, address) public override returns (uint256 assets) {
-        uint256 assets2 = convertToAssets(shares);
+    function mint(uint256 shares, address) public returns (uint256 assets) {
+        uint256 assets2 = vault.convertToAssets(shares);
         LastDeposit memory newDeposit = LastDeposit({
             amount: assets2,
-            roundId: vaultState.currentRoundId,
+            roundId: vault.___vaultState().currentRoundId,
             shares: shares
         });
         lastDeposits[msg.sender] = newDeposit;
-        return this.mint(shares, msg.sender);
+        return vault.mint(shares, msg.sender);
     }
 
     function withdraw(
         uint256 assets,
         address,
         address
-    ) public override returns (uint256 shares) {
-        bool isNextRound = vaultState.currentRoundId == lastDeposits[msg.sender].roundId + 1;
-        uint256 burnShares = _convertToShares(assets, Math.Rounding.Up);
+    ) public returns (uint256 shares) {
+        bool isNextRound = vault.___vaultState().currentRoundId == lastDeposits[msg.sender].roundId + 1;
+        uint256 burnShares = vault.___convertToShares(assets, Math.Rounding.Up);
 
-        this.withdraw(assets, msg.sender, msg.sender);
-        uint256 userSharesAfterWithdraw = this.balanceOf(msg.sender);
+        vault.withdraw(assets, msg.sender, msg.sender);
+        uint256 userSharesAfterWithdraw = vault.balanceOf(msg.sender);
 
         if (isNextRound && assets > 0) {
             if (burnShares < lastDeposits[msg.sender].shares) {
@@ -143,10 +161,7 @@ contract STETHVaultInvariants is STETHVault, FuzzyAddresses {
                 lastDeposits[msg.sender].amount -= assets;
             }
             if (burnShares == lastDeposits[msg.sender].shares || userSharesAfterWithdraw == 0) {
-                bool isWithdrawLowerThanInitial = assets < lastDeposits[msg.sender].amount;
-                if (isWithdrawLowerThanInitial) {
-                    emit AssertionFailed(isWithdrawLowerThanInitial);
-                }
+                assert(assets >= lastDeposits[msg.sender].amount);
             }
         }
     }
@@ -155,36 +170,33 @@ contract STETHVaultInvariants is STETHVault, FuzzyAddresses {
         uint256 shares,
         address,
         address
-    ) public override returns (uint256 assets) {
-        bool isNextRound = vaultState.currentRoundId == lastDeposits[msg.sender].roundId + 1;
-        uint256 assetsToWithdraw = convertToAssets(shares);
-        uint256 balanceOfShares = this.balanceOf(msg.sender);
-        this.redeem(shares, msg.sender, msg.sender);
+    ) public returns (uint256 assets) {
+        bool isNextRound = vault.___vaultState().currentRoundId == lastDeposits[msg.sender].roundId + 1;
+        uint256 assetsToWithdraw = vault.convertToAssets(shares);
+        uint256 balanceOfShares = vault.balanceOf(msg.sender);
+        vault.redeem(shares, msg.sender, msg.sender);
         if (isNextRound && shares > 0) {
             if (shares < lastDeposits[msg.sender].shares) {
                 lastDeposits[msg.sender].shares -= shares;
                 lastDeposits[msg.sender].amount -= assetsToWithdraw;
             }
             if (shares == lastDeposits[msg.sender].shares || shares == balanceOfShares) {
-                bool isWithdrawLowerThanInitial = assetsToWithdraw < lastDeposits[msg.sender].amount;
-                if (isWithdrawLowerThanInitial) {
-                    emit AssertionFailed(isWithdrawLowerThanInitial);
-                }
+                assert(lastDeposits[msg.sender].amount >= assetsToWithdraw);
             }
         }
     }
 
-    function transfer(address to, uint256 amount) public override(ERC20, IERC20) returns (bool) {
+    function transfer(address to, uint256 amount) public returns (bool) {
         if (!_addressIsAllowed(to)) return false;
-        return super.transfer(to, amount);
+        return vault.transfer(to, amount);
     }
 
     function transferFrom(
         address from,
         address to,
         uint256 amount
-    ) public override(ERC20, IERC20) returns (bool) {
+    ) public returns (bool) {
         if (!_addressIsAllowed(to)) return false;
-        return super.transferFrom(from, to, amount);
+        return vault.transferFrom(from, to, amount);
     }
 }

--- a/test/invariants/STETHVaultInvariants.sol
+++ b/test/invariants/STETHVaultInvariants.sol
@@ -9,8 +9,6 @@ import "../../contracts/mocks/InvestorActorMock.sol";
 import "../../contracts/mocks/YieldSourceMock.sol";
 
 contract STETH is Asset {
-    event Log(int256);
-
     constructor() Asset("Liquid staked Ether 2.0", "stETH") {}
 
     function transferFrom(
@@ -88,13 +86,6 @@ contract STETHVaultInvariants is FuzzyAddresses {
     uint256 private constant MAX_ERROR_WITHDRAWAL = 100; // max accepted withdrawal loss due to rounding is 1% of deposited amount
     uint256 private constant MAX_REBASE = 2; // 5% APR from Lido is approximately 0.02% daily
     uint256 private constant MAX_INVESTOR_GENERATED_PREMIUM = 100; // expected max investor premium generated is 1% of the Vault's TVL
-
-    event LogBytes(bytes);
-    event LogString(string);
-    event LogUint(uint256);
-    event LogUint2(uint256, uint256);
-    event D(address, uint256);
-    event W(address, uint256);
 
     mapping(address => uint256) private deposits;
     mapping(address => uint256) private withdraws;

--- a/test/invariants/config.yaml
+++ b/test/invariants/config.yaml
@@ -34,6 +34,7 @@ sender: ["0x10000", "0x20000", "0x30000"]
 # balanceAddr: 0xffffffff
 # #balanceContract overrides balanceAddr for the contract address
 # balanceContract: 0
+codeSize: 0x12000
 # #solcArgs allows special args to solc
 # solcArgs: ""
 # #solcLibs is solc libraries


### PR DESCRIPTION
# Description

This pull request fixes the invariant tests from `STETHVaultInvariants.sol`

# Summary of changes

### 1. Change state variables from public to private

The previous setup simply extended from `STETHVault`, which exposed a large number of `public` and `external` functions to echidna, taking forever to process. 

```
Tests found: 70
Seed: 3379254151187803815
Unique instructions: 7551
Unique codehashes: 3
Corpus size: 3
```

For example, none of those made sense to be tested:

```
assertion in INVESTOR_RATIO(): fuzzing (3858/100000)
assertion in controller(): fuzzing (3858/100000)
assertion in $configuration(): fuzzing (3858/100000)
```

Not even an `r3.2xlarge` instance (32 GB RAM) was enough to handle the previous setup, as the process reverted due to an out-of-memory error.

```
[Mon Mar  6 17:04:14 2023] Out of memory: Killed process 3664 (echidna-test) total-vm:1074278180kB, anon-rss:32011756kB, file-rss:0kB, shmem-rss:0kB, UID:1000 pgtables:62808kB oom_score_adj:0
```

In order to guarantee that echidna only calls relevant functions, we cannot use inheritance (`InvariantTest is Vault...`), and we should rather use composition (`Vault private vault = new Vault()` inside the test constructor).

However, since the vault contains separate accounting for each user, we should not use the test contract to directly interact with the vault. To handle that, we use the ["user proxy"](https://github.com/crytic/echidna-streaming-series/blob/main/part3/contracts/crytic/Setup.sol) strategy highlighted in the [Learn how to fuzz like a pro: Intro to AMM’s invariants](https://www.youtube.com/live/n0RaKKVTGvA?feature=share&t=4255) tutorial from Trail of Bits. Essentially, the test contract contains a list of `User` contracts that they interact with the vault themselves. For the sake of simplicity, we choose echidna's users to be the vault depositors and the test contract to be the vault controller. 

### 2. Remove unused parameters from public functions

Echidna will try to fuzz all function parameters to guarantee that different corner cases are caught. This means that a `function foo(uint256 a, address b)` will have both `a` and `b` tested against a large number of values to try to break the invariants. 

The previous implementation of `STETHVaultInvariants` was not efficiently taking this into consideration, as it contained a large number of unused parameters (e.g. `function withdraw(uint256 assets, address, address)` on public/external functions. 

This meant that, although echidna would call these functions with different values for each parameter, they would simply be discarded by the function implementation.

As a result, the test was **not reaching 100% coverage** even after a high number of iterations (10 thousand). This could be seen by analyzing the coverage report (`echidna/corpus/covered.<timestamp>.html`, which had a large number of red-colored lines (meaning, unreached code). 

Analyzing the test coverage was extremely important to understand that, although the test was initially passing after change `1. Change state variables from public to private`, it was not really testing anything, as the relevant pieces of the code were not being executed. 

All unused parameters were removed. For example, `withdraw` became simply `function withdraw(uint256 assets)`.

### 3. Optimize fuzzer performance

Fuzzer inputs are bounded with arithmetic computation in order not to waste fuzzer runs, as suggested by the [Learn how to fuzz like a pro: Fuzzing Arithmetics](https://www.youtube.com/watch?v=9P7sqE6hILM&t=3432s) tutorial from Trail of Bits.

For example, instead of returning if the input is invalid, it is preferred to manipulate the value (with `Math.min`, `Math.max`, `value + 1`, etc.) in order to continue the function flow:

```
// before
    function generateInterest(uint256 a) public {
        if (a == 0) return;
        uint256 addInterest = (totalAssets() / a);
        $asset.generateInterest(addInterest);
    }
```

```
// after
    function positiveRebase(uint256 amount) public {
        amount = Math.min(amount, ($asset.totalSupply() * MAX_INVESTOR_GENERATED_PREMIUM) / vault.DENOMINATOR());
        $asset.rebase(address(vault), int256(amount));
    }
```

### 4. Change logic of "withdrawal after deposit" 

The previous implementation had a mapping of user to `LastDeposit`. If I am not mistaken, there could be a case where a user would deposit at round N, deposit process round N+1, then withdraw at round N+2. In this case, the property check from the test would not be verified.  Because of that, I changed the logic to verify if `vault.totalIdleAssets` is zero (meaning, assets have been processed). I believe the previous problem still exists, but at least the code is cleaner.