### PR TITLE
Add synchronize to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,12 @@
 
 name: lint+compile+test
+
 on:
-  push
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
 
 jobs:
   coverage:


### PR DESCRIPTION
This avoids running multiple CI runs on the same PR.
Only the latest will run.